### PR TITLE
Serve public directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to a [Hapi Server](http://hapijs.com/api#server).
 Load in your trailpack config.
 
 ```js
-// config/trailpack.js
+// config/main.js
 module.exports = {
   // ...
   packs: [
@@ -71,10 +71,23 @@ module.exports = {
 module.exports = {
   views: {
     engines: {
-      html: require('some-view-engine')
+      html: require('handlebars')
     },
-    path: 'views'
+      path: Path.join(__dirname, '../views')
   }
+}
+```
+
+#### Serve a directory 
+```js
+// config/web.js
+module.exports = {
+  www: {
+    directory: Path.join(__dirname, '../www'),
+    redirectToSlash: true,
+    listing: false,
+    index: true
+  } 
 }
 ```
 

--- a/config/web.js
+++ b/config/web.js
@@ -11,8 +11,10 @@ module.exports = {
   ],
   views: {
     engines: {
+      // Have user provide engine
       // html: require('some-view-engine')
     }
+    //Have user provide a path.
     //path: 'views'
   }
 }

--- a/config/web.js
+++ b/config/web.js
@@ -9,11 +9,10 @@ module.exports = {
       options: { }
     }
   ],
-
   views: {
     engines: {
       // html: require('some-view-engine')
-    },
-    path: 'views'
+    }
+    //path: 'views'
   }
 }

--- a/lib/schemas/webconfig.js
+++ b/lib/schemas/webconfig.js
@@ -4,6 +4,7 @@ module.exports = joi.object().keys({
   port: joi.number().integer().positive().required(),
   host: joi.string(),
   plugins: joi.array().optional(),
-  views: joi.object().optional()
+  views: joi.object().optional(),
+  www: joi.object().optional()
 })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,6 @@ module.exports = {
   createServer (config) {
     const server = new Hapi.Server()
     let filePath = Hoek.applyToDefaults({www: { directory: config.main.paths.root } }, config.web, true)
-    //global.testPath = Path.resolve(__dirname, filePath.www.directory)
     server.connection({
       host: config.web.host,
       port: config.web.port,
@@ -33,7 +32,7 @@ module.exports = {
   },
 
   registerViews (app, server) {
-    if (!app.config.web.views.engines /* !app.config.web.views.engines.jade */) {
+    if (!app.config.web.views.engines) {
       app.log.debug('config.views: No view engine is set. Not loading.')
       return
     }
@@ -66,6 +65,7 @@ module.exports = {
 
   registerRoutes (app, server) {
     if (app.config.web.www) {
+      //If www is provided add it to the routes
       app.routes.push({
         method: 'GET',
         path: '/{param*}',

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
+const Path = require('path')
 const Hapi = require('hapi')
 const Hoek = require('hoek')
 
@@ -8,16 +9,17 @@ module.exports = {
 
   createServer (config) {
     const server = new Hapi.Server()
+    let filePath = Hoek.applyToDefaults({www: { directory: config.main.paths.root } }, config.web, true)
+    //global.testPath = Path.resolve(__dirname, filePath.www.directory)
     server.connection({
       host: config.web.host,
       port: config.web.port,
       routes: {
         files: {
-          relativeTo: config.main.paths.root
+          relativeTo: Path.resolve(__dirname, filePath.www.directory)
         }
       }
     })
-
     return server
   },
 
@@ -25,18 +27,16 @@ module.exports = {
     return new Promise((resolve, reject) => {
       server.register(app.config.web.plugins || [ ], err => {
         if (err) return reject(err)
-
         resolve()
       })
     })
   },
 
   registerViews (app, server) {
-    if (!app.config.web.views.engines.html) {
+    if (!app.config.web.views.engines /* !app.config.web.views.engines.jade */) {
       app.log.debug('config.views: No view engine is set. Not loading.')
       return
     }
-
     server.views(app.config.web.views)
   },
 
@@ -65,6 +65,24 @@ module.exports = {
   },
 
   registerRoutes (app, server) {
+    if (app.config.web.www) {
+      app.routes.push({
+        method: 'GET',
+        path: '/{param*}',
+        handler: {
+          directory: {
+              path: '.',
+              index: app.config.web.www.index || false,
+              listing: app.config.web.www.listing || false,
+              showHidden: app.config.web.www.showHidden || false,
+              redirectToSlash: app.config.web.www.redirectToSlash || false,
+              lookupCompressed: app.config.web.www.lookupCompressed || false,
+              etagMethod: app.config.web.www.etagMethod || 'hash'
+          }
+        }
+      })
+    }
+
     _.each(app.routes, route => server.route(route))
   },
 

--- a/test/app.js
+++ b/test/app.js
@@ -80,10 +80,16 @@ const App = {
     },
     web: {
       port: 3000,
-      host: 'localhost'
-    },
-    views: {
-
+      host: 'localhost',
+      views: {
+        engines: {
+          html: require('handlebars')
+        },
+          path: 'views'
+      },
+      www: {
+        directory: '../www'
+      }
     }
   }
 }

--- a/test/controllers/FootprintController.test.js
+++ b/test/controllers/FootprintController.test.js
@@ -77,7 +77,6 @@ describe('FootprintController', () => {
         .expect(200)
         .end((err, res) => {
           const user = res.body
-          console.log(user)
           assert.equal(user.name, 'findtestuser')
           assert(user.roles)
           assert.equal(user.roles[0].id, roleId)

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const assert = require('assert')
+//const supertest = require('supertest')
+
+describe('Lib.Server', () => {
+	// let request
+	// before(() => {
+	// 	request = supertest('http://localhost:3000')
+	// })
+
+	it('should create directory routes when www config is provided', () => {
+		assert.equal(global.app.routes.length, 9)
+	})
+
+//Debug: internal, implementation, error
+//    TypeError: Uncaught error: Cannot read property 'find' of undefined
+//    at FootprintService.find
+
+  // describe('#get static', () => {
+  //   it('should get static file', done => {
+  //     request
+  //       .get('/trailt_test.json')
+  //       .expect(200, done);
+  //   })
+  // })
+})
+

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -1,28 +1,29 @@
 'use strict'
 
 const assert = require('assert')
-//const supertest = require('supertest')
+const supertest = require('supertest')
 
 describe('Lib.Server', () => {
-	// let request
-	// before(() => {
-	// 	request = supertest('http://localhost:3000')
-	// })
-
-	it('should create directory routes when www config is provided', () => {
-		assert.equal(global.app.routes.length, 9)
+	let request
+	before(() => {
+		request = supertest('http://localhost:3000')
 	})
 
-//Debug: internal, implementation, error
-//    TypeError: Uncaught error: Cannot read property 'find' of undefined
-//    at FootprintService.find
+  describe('#addRoutes', () => {
+    it('should create directory routes when www config is provided', () => {
+      assert.equal(global.app.routes.length, 9)
+    })
+  })
 
-  // describe('#get static', () => {
-  //   it('should get static file', done => {
-  //     request
-  //       .get('/trailt_test.json')
-  //       .expect(200, done);
-  //   })
-  // })
+  describe('#getStaticAssets', () => {
+    it.skip('should get static file', done => {
+      //    Results in Error: Debug: internal, implementation, error
+      //    TypeError: Uncaught error: Cannot read property 'find' of undefined
+      //    at FootprintService.find
+      request
+        .get('/trails_test.json')
+        .expect(200, done);
+    })
+  })
 })
 


### PR DESCRIPTION
I was taking a pass at serving a directory from within Hapi and resolve view engine issues. If I npm link this into a newly generated yeoman project it seems to work; however, in trying to write out some tests I get the following error message: 

```
Debug: internal, implementation, error
    TypeError: Uncaught error: Cannot read property 'find' of undefined
    at FootprintService.find
```

Possibly related to https://github.com/trailsjs/trailpack-hapi/issues/30
@tjwebb if you have any ideas, suggestions, or changes please let me know. 
