### PR TITLE
Express similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,17 @@ module.exports = {
 
 #### Static Assets
 ```js
-// config/web.js
+// config/main.js
 module.exports = {
-  assets: 'static'
+  paths: {
+    ...
+    www: 'static'
+    ...
+  }
 }
 ```
+This allows static files such as js or images to be served in the /static directory.
+If you prefer, feel free to use a name other than 'static'!
 
 ## Contributing
 We love contributions! In order to be able to review your code efficiently,

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module.exports = {
 module.exports = {
   paths: {
     ...
-    www: 'static'
+    www: path.resolve(__dirname, '..', 'static')
     ...
   }
 }

--- a/lib/schemas/webconfig.js
+++ b/lib/schemas/webconfig.js
@@ -5,7 +5,6 @@ module.exports = joi.object().keys({
   host: joi.string(),
   plugins: joi.array().optional(),
   views: joi.object().optional(),
-  server: joi.string(),
-  assets: joi.string().optional()
+  server: joi.string()
 })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,7 +54,8 @@ module.exports = {
           }
         }
       })
-    } else {
+    } 
+    else {
       app.log.info('config.paths.www: No www directory is set, static files will not be loaded')
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,6 +54,8 @@ module.exports = {
           }
         }
       })
+    } else {
+      app.log.info('config.paths.www: No www directory is set, static files will not be loaded')
     }
 
   },

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ module.exports = {
   registerRoutes (app, server) {
     _.each(app.routes, route => server.route(route))
 
-    if (app.config.web.assets) {
+    if (app.config.main.paths.www) {
       server.route({
         method: 'GET',
         path: '/' + app.config.main.paths.www + '/{filename*}',

--- a/lib/server.js
+++ b/lib/server.js
@@ -46,10 +46,10 @@ module.exports = {
     if (app.config.web.assets) {
       server.route({
         method: 'GET',
-        path: '/' + app.config.web.assets + '/{filename*}',
+        path: '/' + app.config.main.paths.www + '/{filename*}',
         handler: {
           file: function(request) {
-            return path.join(app.config.web.assets, request.params.filename)
+            return path.join(app.config.main.paths.www, request.params.filename)
           }
         }
       })

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,12 +44,13 @@ module.exports = {
     _.each(app.routes, route => server.route(route))
 
     if (app.config.main.paths.www) {
+      const staticDir = path.relative(app.config.main.paths.root, app.config.main.paths.www)
       server.route({
         method: 'GET',
-        path: '/' + app.config.main.paths.www + '/{filename*}',
+        path: path.join('/', staticDir, '{filename*}'),
         handler: {
           file: function(request) {
-            return path.join(app.config.main.paths.www, request.params.filename)
+            return path.join(staticDir, request.params.filename)
           }
         }
       })

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,7 +54,7 @@ module.exports = {
           }
         }
       })
-    } 
+    }
     else {
       app.log.info('config.paths.www: No www directory is set, static files will not be loaded')
     }


### PR DESCRIPTION
This is an effort to make config uniform between trailpack-hapi and trailpack-express4. trailpack-express4 has the user declare static directory in app.config.main.paths, so we should do that here as well.

See this issue: [75](https://github.com/trailsjs/trailpack-hapi/issues/75)

Also, we need to decide if the user must use path.resolve(...) to declare the static directory. It is required by trailpack-express4 currently: [10](https://github.com/trailsjs/trailpack-express4/issues/10)
